### PR TITLE
Pass args/kwargs into super init

### DIFF
--- a/mistlefoot/core.py
+++ b/mistlefoot/core.py
@@ -89,8 +89,8 @@ class AutoLink(SpanToken):
 
 # %% ../nbs/00_core.ipynb #be9bbac9
 class ExtendedHtmlRenderer(HtmlRenderer):
-    def __init__(self): 
-        super().__init__(Subscript, Superscript, Highlight, Emoji, FootnoteRef, FootnoteEntry, Strikethrough, AutoLink)
+    def __init__(self, *args, **kwargs): 
+        super().__init__(Subscript, Superscript, Highlight, Emoji, FootnoteRef, FootnoteEntry, Strikethrough, AutoLink, *args, **kwargs)
         self.footnotes = {}
     def render_subscript(self, token): return f'<sub>{token.content}</sub>'
     def render_superscript(self, token): return f'<sup>{token.content}</sup>'

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -169,8 +169,8 @@
    "source": [
     "#| export\n",
     "class ExtendedHtmlRenderer(HtmlRenderer):\n",
-    "    def __init__(self): \n",
-    "        super().__init__(Subscript, Superscript, Highlight, Emoji, FootnoteRef, FootnoteEntry, Strikethrough, AutoLink)\n",
+    "    def __init__(self, *args, **kwargs): \n",
+    "        super().__init__(Subscript, Superscript, Highlight, Emoji, FootnoteRef, FootnoteEntry, Strikethrough, AutoLink, *args, **kwargs)\n",
     "        self.footnotes = {}\n",
     "    def render_subscript(self, token): return f'<sub>{token.content}</sub>'\n",
     "    def render_superscript(self, token): return f'<sup>{token.content}</sup>'\n",
@@ -576,7 +576,13 @@
    ]
   }
  ],
- "metadata": {},
+ "metadata": {
+  "kernelspec": {
+   "display_name": "python3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 5
 }


### PR DESCRIPTION
This PR ensures `ExtendedRenderer` supports additional `args` and `kwargs` to pass through to `HtmlRenderer`