### PR TITLE
Fix premature HTML block termination inside fenced code blocks

### DIFF
--- a/mistlefoot/_modidx.py
+++ b/mistlefoot/_modidx.py
@@ -72,5 +72,6 @@ d = { 'settings': { 'branch': 'main',
                                                                                       'mistlefoot/core.py'),
                                  'mistlefoot.core.TagExtractor.handle_starttag': ( 'core.html#tagextractor.handle_starttag',
                                                                                    'mistlefoot/core.py'),
+                                 'mistlefoot.core._fence_state': ('core.html#_fence_state', 'mistlefoot/core.py'),
                                  'mistlefoot.core.opening_tag': ('core.html#opening_tag', 'mistlefoot/core.py'),
                                  'mistlefoot.core.parse_attrs': ('core.html#parse_attrs', 'mistlefoot/core.py')}}}

--- a/mistlefoot/core.py
+++ b/mistlefoot/core.py
@@ -165,8 +165,8 @@ class LenientHtmlBlock(HTMLBlock):
         buf,md,fence = [],cls._md_inner,None
         for line in lines:
             buf.append(line)
-            fence = _fence_state(line, fence)
-            if fence is None and cls._end_cond in line.casefold(): break
+            if md: fence = _fence_state(line, fence)
+            if (not md or fence is None) and cls._end_cond in line.casefold(): break
         if md: return ('md', buf[0], buf[1:-1], buf[-1] if len(buf)>1 else '')
         return buf
 

--- a/mistlefoot/core.py
+++ b/mistlefoot/core.py
@@ -137,6 +137,13 @@ def opening_tag(line):
 
 
 # %% ../nbs/00_core.ipynb #fdb920dd
+def _fence_state(line, fence=None):
+    m = re.match(r'^\s*(`{3,5}|~{3,5})', line)
+    if not m: return fence
+    s = m.group(1)
+    if fence: return None if s[0] == fence[0] and len(s) >= len(fence) else fence
+    return s
+
 class LenientHtmlBlock(HTMLBlock):
     _extra_tags = {'svg'}
     _md_inner = False
@@ -155,10 +162,11 @@ class LenientHtmlBlock(HTMLBlock):
     @classmethod
     def read(cls, lines):
         if cls._end_cond is None or not cls._end_cond.startswith('</'): return super().read(lines)
-        buf,md = [],cls._md_inner
+        buf,md,fence = [],cls._md_inner,None
         for line in lines:
             buf.append(line)
-            if cls._end_cond in line.casefold(): break
+            fence = _fence_state(line, fence)
+            if fence is None and cls._end_cond in line.casefold(): break
         if md: return ('md', buf[0], buf[1:-1], buf[-1] if len(buf)>1 else '')
         return buf
 

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -249,6 +249,13 @@
    "outputs": [],
    "source": [
     "#| export\n",
+    "def _fence_state(line, fence=None):\n",
+    "    m = re.match(r'^\\s*(`{3,5}|~{3,5})', line)\n",
+    "    if not m: return fence\n",
+    "    s = m.group(1)\n",
+    "    if fence: return None if s[0] == fence[0] and len(s) >= len(fence) else fence\n",
+    "    return s\n",
+    "\n",
     "class LenientHtmlBlock(HTMLBlock):\n",
     "    _extra_tags = {'svg'}\n",
     "    _md_inner = False\n",
@@ -267,10 +274,11 @@
     "    @classmethod\n",
     "    def read(cls, lines):\n",
     "        if cls._end_cond is None or not cls._end_cond.startswith('</'): return super().read(lines)\n",
-    "        buf,md = [],cls._md_inner\n",
+    "        buf,md,fence = [],cls._md_inner,None\n",
     "        for line in lines:\n",
     "            buf.append(line)\n",
-    "            if cls._end_cond in line.casefold(): break\n",
+    "            fence = _fence_state(line, fence)\n",
+    "            if fence is None and cls._end_cond in line.casefold(): break\n",
     "        if md: return ('md', buf[0], buf[1:-1], buf[-1] if len(buf)>1 else '')\n",
     "        return buf\n",
     "\n",
@@ -598,6 +606,94 @@
    ],
    "source": [
     "render_md(\"==highlighted== and :smile: :rocket: :heart:\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4e85b688",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<details>\n",
+       "```html\n",
+       "<details markdown='1'>\n",
+       "hi\n",
+       "</details>\n",
+       "```\n",
+       "</details>\n"
+      ],
+      "text/plain": [
+       "HTML(<details>\n",
+       "```html\n",
+       "<details markdown='1'>\n",
+       "hi\n",
+       "</details>\n",
+       "```\n",
+       "</details>\n",
+       ")"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "render_md(\"\"\"\n",
+    "<details>\n",
+    "```html\n",
+    "<details markdown='1'>\n",
+    "hi\n",
+    "</details>\n",
+    "```\n",
+    "</details>\n",
+    "\"\"\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a1d5acb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<details markdown='1'>\n",
+       "<pre><code class=\"language-html\">&lt;details markdown='1'&gt;\n",
+       "hi\n",
+       "&lt;/details&gt;\n",
+       "</code></pre></details>\n",
+       "\n"
+      ],
+      "text/plain": [
+       "HTML(<details markdown='1'>\n",
+       "<pre><code class=\"language-html\">&lt;details markdown='1'&gt;\n",
+       "hi\n",
+       "&lt;/details&gt;\n",
+       "</code></pre></details>\n",
+       "\n",
+       ")"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "render_md(\"\"\"\n",
+    "<details markdown='1'>\n",
+    "```html\n",
+    "<details markdown='1'>\n",
+    "hi\n",
+    "</details>\n",
+    "```\n",
+    "</details>\n",
+    "\"\"\")"
    ]
   },
   {
@@ -1029,7 +1125,7 @@
  "metadata": {
   "solveit": {
    "default_code": false,
-   "mode": "concise",
+   "mode": "learning",
    "use_fence": false,
    "use_thinking": true,
    "use_tools": true,


### PR DESCRIPTION
## Problem

When parsing HTML blocks with inner markdown, a closing tag (e.g. `</details>`) appearing inside a fenced code block would incorrectly terminate the HTML block early.

 ## Solution

Introduce `_fence_state()` to track whether the parser is currently inside a fenced code block. The end condition check in `LenientHtmlBlock.read()` is now skipped while inside a fence, preventing false-positive matches on closing tags within code blocks.